### PR TITLE
Higher max temperature treshold for AC accessories

### DIFF
--- a/src/lib/accessories/AirConditionerAccessory.ts
+++ b/src/lib/accessories/AirConditionerAccessory.ts
@@ -65,7 +65,7 @@ export class AirConditionerAccessory {
         this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
             .setProps({
                 minValue: 16,
-                maxValue: 28,
+                maxValue: 30,
                 minStep: 1,
             })
             .onGet(this.getCoolingThresholdTemperatureCharacteristic.bind(this))


### PR DESCRIPTION
Higher max temperature treshold for AC accessories (duplicated temperature max from IR AC device in Tuya Smart app)