### PR TITLE
Don't send any empty request body object on GET

### DIFF
--- a/src/lib/api/APIInvocationHelper.ts
+++ b/src/lib/api/APIInvocationHelper.ts
@@ -58,7 +58,10 @@ export class APIInvocationHelper {
             log.error(err.message, err.stack);
             callback({ msg: `Failed to invoke API '${err.message}'` });
         })
-        req.write(JSON.stringify(body));
+
+        if(method != "GET")
+            req.write(JSON.stringify(body));
+
         req.end();
     }
 


### PR DESCRIPTION
This fixes #102.

This patch does not fix the underlying issue which is that `request` has been deprecated & unmaintained for a long time.

> As of Feb 11th 2020, request is fully deprecated. No new
> changes are expected land. In fact, none have landed for 
> some time.
> 
> For more information about why request is deprecated and 
> possible alternatives refer to
> [this issue](https://github.com/request/request/issues/3142).