### PR TITLE
Widen engines.node to >=18.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "engines": {
     "homebridge": "^1.6.0 || ^2.0.0-beta.0",
-    "node": "^18.20.4 || ^20.15.1 || ^22"
+    "node": ">=18.0.0"
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Changes `engines.node` from `^18.20.4 || ^20.15.1 || ^22` to `>=18.0.0`
- The previous range unnecessarily excluded valid earlier patch versions (e.g. 18.19.x, 20.10.x)

## Testing
Plugin verified working on Node v22.22.1; no Node 18.20.4+ or 20.15.1+ specific APIs are used.